### PR TITLE
Add dynamic blog posts from S3

### DIFF
--- a/S3_SETUP.md
+++ b/S3_SETUP.md
@@ -1,0 +1,69 @@
+# Using S3 for Dynamic Blog Posts
+
+This application can fetch blog posts and images directly from an Amazon S3 bucket at runtime. This allows you to add new markdown files without redeploying the site.
+
+## 1. Bucket Structure
+
+```
+<your-bucket>/
+├── index.json            # list of markdown files
+├── posts/
+│   └── <post>.md         # markdown articles
+└── images/
+    └── <image files>
+```
+
+- **index.json** – JSON array containing the filenames found in the `posts/` directory, e.g.:
+  ```json
+  [
+    "2025-06-23-sample-post.md",
+    "2025-06-25-another-post.md"
+  ]
+  ```
+- **posts/** – contains the markdown files. These use the same front‑matter format as local posts.
+- **images/** – any images referenced from the S3 posts. Use relative paths (e.g. `my-image.png`).
+
+## 2. CORS Configuration
+
+Enable CORS on the bucket to allow `GET` requests from your domain (e.g. `https://your-site.netlify.app`). A typical CORS configuration is:
+
+```xml
+<CORSConfiguration>
+  <CORSRule>
+    <AllowedOrigin>*</AllowedOrigin>
+    <AllowedMethod>GET</AllowedMethod>
+    <MaxAgeSeconds>3000</MaxAgeSeconds>
+    <AllowedHeader>*</AllowedHeader>
+  </CORSRule>
+</CORSConfiguration>
+```
+
+## 3. Environment Variable
+
+Set the environment variable `VITE_S3_BASE_URL` in Netlify (or your hosting provider). The value should be the public URL to the bucket root, for example:
+
+```
+https://my-blog-bucket.s3.amazonaws.com
+```
+
+## 4. Adding a New Post
+
+1. Upload the markdown file to the `posts/` folder.
+2. Upload any referenced images to the `images/` folder.
+3. Update `index.json` to include the new markdown file name.
+   - The website will fetch `index.json` on page load and automatically display the new post.
+
+Image paths inside the markdown front‑matter should be relative when stored in S3:
+
+```yaml
+image: "hero.png"        # resolves to <bucket>/images/hero.png
+```
+
+If the path starts with `/` or `http`, it will be used as provided (for local images or external URLs).
+
+## 5. Local Posts
+
+Markdown files placed inside `src/blogs/posts/` continue to work alongside the S3 posts. Both sources are combined automatically.
+
+---
+By following this structure you can publish new articles by simply uploading files to S3 and editing `index.json`; no rebuild is required.

--- a/bucket-policy.json
+++ b/bucket-policy.json
@@ -1,0 +1,21 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowSESPuts",
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "ses.amazonaws.com"
+            },
+            "Action": "s3:PutObject",
+            "Resource": "arn:aws:s3:::dialogtuple-s3/*"
+        },
+        {
+            "Sid": "PublicReadGetObject",
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::dialogtuple-s3/*"
+        }
+    ]
+} 

--- a/cors.json
+++ b/cors.json
@@ -1,0 +1,18 @@
+[
+    {
+        "AllowedHeaders": [
+            "*"
+        ],
+        "AllowedMethods": [
+            "GET"
+        ],
+        "AllowedOrigins": [
+            "https://www.dialogtuple.com",
+            "http://localhost:5173",
+            "http://localhost:3000",
+            "https://*.netlify.app"
+        ],
+        "ExposeHeaders": [],
+        "MaxAgeSeconds": 3000
+    }
+] 

--- a/sample-s3-blog.md
+++ b/sample-s3-blog.md
@@ -1,0 +1,60 @@
+---
+title: "Testing S3 Integration: Image Paths Without Leading Slash"
+date: "2025-07-22"
+author: "Dialogtuple Team"
+authorPicture: "/dialoglogo.png"
+description: "A test blog post to verify S3 integration works with image paths that don't start with a forward slash."
+tags: ["S3 Integration", "Testing", "Image Handling", "Blog System", "AWS"]
+image: "test_image.png"
+slug: "s3-integration-test"
+---
+
+# Testing S3 Integration: Image Paths Without Leading Slash
+
+This is a test blog post to verify that the S3 integration works correctly with image paths that don't start with a forward slash.
+
+![Test Image](test_image.png)
+
+## What We're Testing
+
+This blog post uses:
+- **Image path**: `test_image.png` (no leading `/`)
+- **Expected behavior**: Should resolve to `https://dialogtuple-s3.s3.ap-south-1.amazonaws.com/images/test_image.png`
+
+## The Image Path Logic
+
+The system should:
+1. Detect this is an S3 blog post (`isFromS3 = true`)
+2. Take the image path `test_image.png`
+3. Convert it to the full S3 URL
+4. Display the image correctly
+
+## Test Scenarios
+
+### Frontmatter Image
+```yaml
+image: "test_image.png"  # No leading slash
+```
+
+### Inline Image
+```markdown
+![Test Image](test_image.png)  # No leading slash
+```
+
+## Expected Result
+
+If everything works correctly:
+- ✅ The image should display in the blog post
+- ✅ The image URL should be the full S3 path
+- ✅ The image should load from your S3 bucket
+
+## Next Steps
+
+1. Upload this markdown file to S3 `posts/` folder
+2. Upload `test_image.png` to S3 `images/` folder  
+3. Update `index.json` to include this file
+4. Test the blog post on your website
+
+---
+
+*This is a test post to verify S3 integration functionality.* 

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -195,7 +195,7 @@ export default function Hero() {
               </p>
             </div>
             <p className={`text-3xl md:text-4xl lg:text-5xl mb-8 max-w-4xl text-white font-bold leading-tight tracking-tight transition-all duration-1000 delay-500 ease-out ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}>
-              Multi-Agent Chatbots. Enterprise-Ready. Customizable. <span className="bg-gradient-to-r from-[#8b5cf6] via-[#6366f1] to-[#3b82f6] text-transparent bg-clip-text">Anywhere</span>
+              Multi-Agent Assistants. Enterprise-Ready. Customizable. <span className="bg-gradient-to-r from-[#8b5cf6] via-[#6366f1] to-[#3b82f6] text-transparent bg-clip-text">Anywhere</span>
             </p>
             <p className={`text-xl md:text-2xl mb-16 max-w-3xl text-white font-medium leading-relaxed tracking-wide transition-all duration-1000 delay-700 ease-out ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}>
               A cutting-edge accelerator blending traditional chatbot platforms with modern multi-agent capabilities, enabling intelligent, context-aware routing and interactions.

--- a/src/utils/blogLoader.ts
+++ b/src/utils/blogLoader.ts
@@ -21,7 +21,7 @@ async function loadLocalBlogs(): Promise<BlogPost[]> {
       (async () => {
         const markdownContent = (await moduleLoader()) as string;
         const rawPost = parseMarkdown(markdownContent, filename);
-        return processBlogPost(rawPost);
+        return processBlogPost(rawPost, false); // Local blog post
       })()
     );
   }
@@ -42,7 +42,7 @@ async function loadS3Blogs(): Promise<BlogPost[]> {
       if (!res.ok) return null;
       const markdown = await res.text();
       const raw = parseMarkdown(markdown, filename);
-      return processBlogPost(raw);
+      return processBlogPost(raw, true); // S3 blog post
     });
 
     const loaded = await Promise.all(promises);

--- a/src/utils/blogUtils.ts
+++ b/src/utils/blogUtils.ts
@@ -125,7 +125,15 @@ export async function markdownToHtml(markdownContent: string): Promise<string> {
 export async function processBlogPost(rawPost: RawBlogPost): Promise<BlogPost> {
   const htmlContent = await markdownToHtml(rawPost.content);
   const excerpt = generateExcerpt(rawPost.content);
-  
+
+  let image = rawPost.frontmatter.image;
+  if (image && !image.startsWith('/') && !image.startsWith('http')) {
+    const base = import.meta.env.VITE_S3_BASE_URL as string | undefined;
+    if (base) {
+      image = `${base}/images/${image}`;
+    }
+  }
+
   return {
     slug: rawPost.slug,
     title: rawPost.frontmatter.title,
@@ -134,7 +142,7 @@ export async function processBlogPost(rawPost: RawBlogPost): Promise<BlogPost> {
     authorPicture: rawPost.frontmatter.authorPicture,
     description: rawPost.frontmatter.description,
     tags: rawPost.frontmatter.tags,
-    image: rawPost.frontmatter.image,
+    image,
     content: htmlContent,
     excerpt
   };

--- a/src/utils/blogUtils.ts
+++ b/src/utils/blogUtils.ts
@@ -122,16 +122,19 @@ export async function markdownToHtml(markdownContent: string): Promise<string> {
 /**
  * Process raw blog post data into final BlogPost format
  */
-export async function processBlogPost(rawPost: RawBlogPost): Promise<BlogPost> {
+export async function processBlogPost(rawPost: RawBlogPost, isFromS3: boolean = false): Promise<BlogPost> {
   const htmlContent = await markdownToHtml(rawPost.content);
   const excerpt = generateExcerpt(rawPost.content);
 
   let image = rawPost.frontmatter.image;
-  if (image && !image.startsWith('/') && !image.startsWith('http')) {
+  if (image && !image.startsWith('http')) {
     const base = import.meta.env.VITE_S3_BASE_URL as string | undefined;
-    if (base) {
-      image = `${base}/images/${image}`;
+    if (base && isFromS3) {
+      // Only convert to S3 URL for S3 blog posts
+      const imageName = image.startsWith('/') ? image.slice(1) : image;
+      image = `${base}/images/${imageName}`;
     }
+    // For local blog posts, keep the image path as-is (will resolve from public folder)
   }
 
   return {


### PR DESCRIPTION
## Summary
- combine local markdown posts with posts hosted on S3
- resolve image paths from S3 when necessary
- document required S3 bucket layout and configuration

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run build` *(fails: vite not found)*
- `npx tsc -p tsconfig.app.json` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_b_6864fe8197dc832d888c4490f08e74ab